### PR TITLE
fix(mac): fall back to AppleScript-elevated networksetup when bundled…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,8 @@ export function disableProxy(sudo?: boolean): boolean;
 
 export function getMacProxyHelper(): string | undefined;
 
+export function isMacProxyHelperUsable(proxyHelper?: string): boolean;
+
 export function getUid(file: string): number | undefined;
 
 export function getBypass(bypass: string): string[] | undefined;

--- a/index.js
+++ b/index.js
@@ -94,6 +94,14 @@ exports.getMacProxyHelper = function() {
   return getProxyMgr().PROXY_HELPER;
 };
 
+exports.isMacProxyHelperUsable = function(proxyHelper) {
+  var mgr = getProxyMgr();
+  if (typeof mgr.isHelperUsable !== 'function') {
+    return true;
+  }
+  return mgr.isHelperUsable(proxyHelper);
+};
+
 exports.getUid = function(file) {
   var getUid = getProxyMgr().getUid;
   return getUid && getUid(file);

--- a/lib/mac/index.js
+++ b/lib/mac/index.js
@@ -12,15 +12,88 @@ var SUDO = [
   'sudo chmod a+rx+s "' + PROXY_HELPER + '"'
 ].join('&&');
 
+// Cached probe: does the bundled x86_64 helper actually run on this machine?
+// On Apple Silicon without Rosetta 2, exec'ing the helper fails with EBADARCH.
+// We probe once with `-h` and reuse the result for the lifetime of the process.
+var helperUsable;
+function isHelperUsable(proxyHelper) {
+  if (helperUsable !== undefined) {
+    return helperUsable;
+  }
+  try {
+    execSync('\'' + proxyHelper + '\' -h', IGNORE_STDIO);
+    helperUsable = true;
+  } catch (e) {
+    helperUsable = false;
+  }
+  return helperUsable;
+}
+
 function execSafe(cmd) {
   try {
     return execSync(cmd, IGNORE_STDIO);
   } catch (e) {}
 }
 
+// Run a batch of shell commands under a single admin prompt via AppleScript.
+// Used as a fallback when the privileged helper binary cannot run
+// (e.g. Apple Silicon without Rosetta 2 — the bundled helper is x86_64-only).
+function execAdmin(commands) {
+  if (!commands || !commands.length) {
+    return;
+  }
+  var script = commands.join(' ; ');
+  var apple = 'do shell script "' + script.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+    + '" with administrator privileges';
+  var shellSafe = apple.replace(/'/g, "'\\''");
+  return execSync("osascript -e '" + shellSafe + "'", IGNORE_STDIO);
+}
+
+function joinBypass(bypass) {
+  if (!bypass) {
+    return '';
+  }
+  // bypass may be an array (from getBypass) or a string.
+  if (Array.isArray(bypass)) {
+    return bypass.map(function(h) { return '"' + h + '"'; }).join(' ');
+  }
+  return String(bypass).split(/[\s,;]+/).filter(Boolean).map(function(h) {
+    return '"' + h + '"';
+  }).join(' ');
+}
+
+function buildEnableCommands(options) {
+  var host = options.host + ' ' + options.port;
+  var bypass = joinBypass(options.bypass);
+  var commands = [];
+  getAllNetworkServicesSync().forEach(function(service) {
+    ['-setftpproxystate', '-setsocksfirewallproxystate', '-setproxyautodiscovery',
+      '-setautoproxystate', '-setstreamingproxystate', '-setgopherproxystate'].forEach(function(cmd) {
+      commands.push('networksetup ' + cmd + ' "' + service + '" off');
+    });
+    commands.push('networksetup -setproxybypassdomains "' + service + '" ' + (bypass || '""'));
+    commands.push('networksetup -setwebproxy "' + service + '" ' + host);
+    commands.push('networksetup -setsecurewebproxy "' + service + '" ' + host);
+  });
+  return commands;
+}
+
+function buildDisableCommands() {
+  var commands = [];
+  getAllNetworkServicesSync().forEach(function(service) {
+    ['-setftpproxystate', '-setsocksfirewallproxystate', '-setproxyautodiscovery',
+      '-setautoproxystate', '-setstreamingproxystate', '-setgopherproxystate',
+      '-setwebproxystate', '-setsecurewebproxystate'].forEach(function(cmd) {
+      commands.push('networksetup ' + cmd + ' "' + service + '" off');
+    });
+    commands.push('networksetup -setproxybypassdomains "' + service + '" ""');
+  });
+  return commands;
+}
+
 function offAll() {
   getAllNetworkServicesSync().forEach(function(service) {
-    ['-setftpproxystat', '-setsocksfirewallproxystate', '-setproxyautodiscovery', '-setautoproxystate',
+    ['-setftpproxystate', '-setsocksfirewallproxystate', '-setproxyautodiscovery', '-setautoproxystate',
     '-setstreamingproxystate', '-setgopherproxystate'].forEach(function(cmd) {
       execSafe('networksetup ' +cmd + ' "' + service + '" off');
     });
@@ -140,18 +213,34 @@ exports.enableProxy = function(options) {
   } else {
     bypass = '';
   }
-  try {
-    execSync('\'' + proxyHelper + '\' -m global -p ' + port + ' -r ' + port + ' -s ' + options.host + bypass, IGNORE_STDIO);
-  } catch (e) {
-    var host = options.host + ' ' + port;
-    offAll();
-    execServicesSync(function(service) {
-      execSync('networksetup -setwebproxy "' + service + '" ' + host, IGNORE_STDIO);
-      execSync('networksetup -setsecurewebproxy "' + service + '" ' + host, IGNORE_STDIO);
-      if (originBypass) {
-        execSafe('networksetup -setproxybypassdomains "' + service + '" ' + originBypass);
-      }
-    });
+  var helperFailed = !isHelperUsable(proxyHelper);
+  if (!helperFailed) {
+    try {
+      execSync('\'' + proxyHelper + '\' -m global -p ' + port + ' -r ' + port + ' -s ' + options.host + bypass, IGNORE_STDIO);
+    } catch (e) {
+      helperFailed = true;
+    }
+  }
+  if (helperFailed) {
+    // The setuid helper is unavailable (typically: Apple Silicon without Rosetta).
+    // Batch every networksetup change into one administrator-elevated AppleScript
+    // so the user only sees a single password prompt.
+    try {
+      execAdmin(buildEnableCommands(options));
+    } catch (e) {
+      // Last-resort: try without elevation. On modern macOS this usually fails
+      // silently for proxy mutations, but it preserves the previous behavior
+      // for environments where networksetup happens to be unprivileged.
+      var host = options.host + ' ' + port;
+      offAll();
+      execServicesSync(function(service) {
+        execSafe('networksetup -setwebproxy "' + service + '" ' + host);
+        execSafe('networksetup -setsecurewebproxy "' + service + '" ' + host);
+        if (originBypass) {
+          execSafe('networksetup -setproxybypassdomains "' + service + '" ' + originBypass);
+        }
+      });
+    }
   }
   try {
     var curProxy = getServerProxySync();
@@ -169,14 +258,24 @@ exports.disableProxy = function(sudo) {
       checkSudo();
     }
   }
-  try {
-    execSync('\''  + proxyHelper + '\' -m off', IGNORE_STDIO);
-  } catch (e) {
-    offAll();
-    execServicesSync(function(service) {
-      execSync('networksetup -setwebproxystate "' + service + '" off', IGNORE_STDIO);
-      execSync('networksetup -setsecurewebproxystate "' + service + '" off', IGNORE_STDIO);
-    });
+  var helperFailed = !isHelperUsable(proxyHelper);
+  if (!helperFailed) {
+    try {
+      execSync('\''  + proxyHelper + '\' -m off', IGNORE_STDIO);
+    } catch (e) {
+      helperFailed = true;
+    }
+  }
+  if (helperFailed) {
+    try {
+      execAdmin(buildDisableCommands());
+    } catch (e) {
+      offAll();
+      execServicesSync(function(service) {
+        execSafe('networksetup -setwebproxystate "' + service + '" off');
+        execSafe('networksetup -setsecurewebproxystate "' + service + '" off');
+      });
+    }
   }
   try {
     var curProxy = getServerProxySync();
@@ -186,3 +285,6 @@ exports.disableProxy = function(sudo) {
 };
 
 exports.getUid = getUid;
+exports.isHelperUsable = function(proxyHelper) {
+  return isHelperUsable(proxyHelper || PROXY_HELPER);
+};


### PR DESCRIPTION
… helper can't run

The bundled mac proxy helper at lib/mac/whistle is x86_64 only. On Apple Silicon (M1/M2/M3/M4) without Rosetta 2 installed, exec'ing the helper fails with EBADARCH. The previous fallback path then tried plain `networksetup` calls without elevation, which silently fail on macOS 11+ because proxy mutations require admin. Net effect: enable/disable does nothing and the user sees no error.

This change:

- Probes the helper once at runtime (`<helper> -h`) and caches the result.
- When the helper is unusable (EBADARCH, missing, not setuid), batches all required `networksetup` mutations into a single `osascript do shell script ... with administrator privileges` invocation. The user sees one password prompt instead of failing silently.
- Adds `isMacProxyHelperUsable()` to the public API so consumers can detect the situation up front (e.g. to show a hint about Rosetta 2 or about needing a universal-binary helper).
- Also fixes a long-standing bypass-list bug in the fallback: the previous code passed a comma-separated string to `networksetup -setproxybypassdomains`, which expects space-separated values. The new path quotes each domain and joins with spaces.
- Fixes a typo (`-setftpproxystat` -> `-setftpproxystate`) in offAll().

Existing behavior on Intel Macs and arm64-with-Rosetta is preserved: the setuid helper is still used as the fast, prompt-free path.